### PR TITLE
introduce cache-dit to longcat-video

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Nothing in this Model Card should be interpreted as altering or restricting the 
 
 [CacheDiT](https://github.com/vipshop/cache-dit) offers Fully Cache Acceleration support for LongCat-Video with DBCache and TaylorSeer, achieved nearly 1.7x speedup without obvious loss of precision. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_longcat_video.py) for more details.
 
-
 ## Citation
 We kindly encourage citation of our work if you find it useful.
 


### PR DESCRIPTION
[CacheDiT](https://github.com/vipshop/cache-dit) offers Fully Cache Acceleration support for LongCat-Video with DBCache and TaylorSeer, achieved nearly 1.7x speedup without obvious loss of precision. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_longcat_video.py) for more details.

- Baseline 

![](https://github.com/vipshop/cache-dit/raw/main/assets/gifs/longcat-video.C1_L0_Q1_NONE.fp8wo.gif)

- w/ cache-dit: ~1.7x speedup!  

![](https://github.com/vipshop/cache-dit/raw/main/assets/gifs/longcat-video.C1_L0_Q1_DBCache_F1B0_W8I1M0MC0_R0.08_T0O0_S22.fp8wo.gif)