### PR TITLE
use python -m pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ conda create -n longcat-video python=3.10
 conda activate longcat-video
 
 # install torch (configure according to your CUDA version)
-pip install torch==2.6.0+cu124 torchvision==0.21.0+cu124 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
+python -m pip install torch==2.6.0+cu124 torchvision==0.21.0+cu124 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
 
 # install flash-attn-2
-pip install ninja 
-pip install psutil 
-pip install packaging 
-pip install flash_attn==2.7.4.post1
+python -m pip install ninja 
+python -m pip install psutil 
+python -m pip install packaging 
+python -m pip install flash_attn==2.7.4.post1
 
 # install other requirements
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 # install longcat-video-avatar requirements
 conda install -c conda-forge librosa
 conda install -c conda-forge ffmpeg
-pip install -r requirements_avatar.txt
+python -m pip install -r requirements_avatar.txt
 
 ```
 
@@ -97,7 +97,7 @@ FlashAttention-2 is enabled in the model config by default; you can also change 
 
 Download models using huggingface-cli:
 ```shell
-pip install "huggingface_hub[cli]"
+python -m pip install "huggingface_hub[cli]"
 huggingface-cli download meituan-longcat/LongCat-Video --local-dir ./weights/LongCat-Video
 huggingface-cli download meituan-longcat/LongCat-Video-Avatar --local-dir ./weights/LongCat-Video-Avatar
 ```


### PR DESCRIPTION
Why use python -m pip?

Sometimes, simply typing pip calls a loop that points to the global Python repository (e.g., /usr/bin/python3), while python -m pip uses the loop you are currently running (the one from your Conda repository).