### PR TITLE
Update flash_attn installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pip install torch==2.6.0+cu124 torchvision==0.21.0+cu124 torchaudio==2.6.0 --ind
 pip install ninja 
 pip install psutil 
 pip install packaging 
-pip install flash_attn==2.7.4.post1
+pip install flash_attn==2.7.4.post1 --no-build-isolation
 
 # install other requirements
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ pip install flash_attn==2.7.4.post1 --no-build-isolation
 # install other requirements
 pip install -r requirements.txt
 
+pip install soundfile==0.13.1
+pip install 'tritonclient[all]==2.64.0'
+
 # install longcat-video-avatar requirements
 conda install -c conda-forge librosa
 conda install -c conda-forge ffmpeg


### PR DESCRIPTION
The official FlashAttention documentation recommends installing with `--no-build-isolation`, precisely so that the compilation uses the torch already installed in your Conda environment. https://github.com/dao-ailab/flash-attention