### PR TITLE
Fix flash-attn install failing with 'No module named torch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pip install torch==2.6.0+cu124 torchvision==0.21.0+cu124 torchaudio==2.6.0 --ind
 pip install ninja 
 pip install psutil 
 pip install packaging 
-pip install flash_attn==2.7.4.post1
+pip install flash_attn==2.7.4.post1 --no-build-isolation
 
 # install other requirements
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-torch==2.6.0
 numpy==1.26.4
 transformers==4.41.0
 loguru==0.7.2
@@ -8,7 +7,6 @@ ftfy==6.2.0
 psutil==6.0.0
 av==12.0.0
 opencv-python==4.9.0.80
-flash-attn==2.7.4.post1
 streamlit==1.50.0
 pyarrow==20.0.0
 imageio==2.37.0


### PR DESCRIPTION
## What

Fixes the `flash_attn` install failure reported in #126
(`ModuleNotFoundError: No module named 'torch'`).

## Why

`flash-attn`'s `setup.py` imports `torch` at build time. pip builds it in an
isolated environment by default, where torch isn't present, so the build fails
even when torch is already installed in the target env.

The failure happens twice with the current setup:

1. The README's `pip install flash_attn==2.7.4.post1` step.
2. `pip install -r requirements.txt`, which also lists `flash-attn`.

## Changes

- README: build flash-attn with `--no-build-isolation` so it links against the
  torch installed in the previous step.
- `requirements.txt`: remove `flash-attn` (installed via its own documented step)
  and `torch` (installed from the cu124 index, so the plain `torch==2.6.0` here
  can pull a CPU build over it).

Fixes #126
