### PR TITLE
Add MiniMax prompt enhancer configuration

### DIFF
--- a/longcat_video/utils/prompt_enhancer.py
+++ b/longcat_video/utils/prompt_enhancer.py
@@ -1,10 +1,10 @@
 import io
+import os
 import re
 import time
 import base64
 
 from PIL import Image
-from openai import OpenAI
 
 
 def compress_image(image_path, max_size_kb=500, quality=85):
@@ -29,7 +29,16 @@ def encode_image(image_bytes):
 
 ### Settings
 
-APPKEY = 'YOUR_APPKEY'
+MINIMAX_API_KEY = "YOUR_MINIMAX_API_KEY"
+MINIMAX_REGION = "global_en"
+MINIMAX_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+MINIMAX_TEXT_MODEL_IDS = ("MiniMax-M3", "MiniMax-M2.7")
+MINIMAX_IMAGE_MODEL_IDS = ("MiniMax-M3",)
+MINIMAX_TEXT_MODEL = MINIMAX_TEXT_MODEL_IDS[0]
+MINIMAX_IMAGE_MODEL = MINIMAX_IMAGE_MODEL_IDS[0]
 
 LM_ZH_SYS_PROMPT = \
     '''用户会输入视频内容描述或者视频任务的描述，你需要基于用户的输入生成优质的视频内容描述，使其更完整、更具表现力，同时不改变原意。\n''' \
@@ -92,6 +101,39 @@ VL_SYS_PROMPT_SHORT_EN = \
 
 ### Util funcitons
 
+def get_minimax_base_url():
+    base_url = os.getenv("MINIMAX_BASE_URL")
+    if base_url:
+        return base_url
+    region = os.getenv("MINIMAX_REGION", MINIMAX_REGION)
+    if region not in MINIMAX_ENDPOINTS:
+        raise ValueError(f"Unsupported MINIMAX_REGION: {region}")
+    return MINIMAX_ENDPOINTS[region]
+
+
+def get_minimax_client():
+    from openai import OpenAI
+
+    return OpenAI(
+        api_key=os.getenv("MINIMAX_API_KEY", MINIMAX_API_KEY),
+        base_url=get_minimax_base_url(),
+    )
+
+
+def get_minimax_text_model():
+    model = os.getenv("MINIMAX_TEXT_MODEL", MINIMAX_TEXT_MODEL)
+    if model not in MINIMAX_TEXT_MODEL_IDS:
+        raise ValueError(f"Unsupported MINIMAX_TEXT_MODEL: {model}")
+    return model
+
+
+def get_minimax_image_model():
+    model = os.getenv("MINIMAX_IMAGE_MODEL", MINIMAX_IMAGE_MODEL)
+    if model not in MINIMAX_IMAGE_MODEL_IDS:
+        raise ValueError(f"Unsupported MINIMAX_IMAGE_MODEL: {model}")
+    return model
+
+
 def is_chinese_prompt(string):
     valid_chars = re.findall(r'[\u4e00-\u9fffA-Za-z0-9]', string)
     if not valid_chars:
@@ -107,9 +149,7 @@ def enhance_prompt_i2v(image_path: str, prompt: str, retry_times: int = 3):
     """
     Enhance a prompt used for text-2-video
     """
-    client = OpenAI(
-        api_key=f"{APPKEY}",
-    )
+    client = get_minimax_client()
 
     compressed_image = compress_image(image_path)
     base64_image = encode_image(compressed_image)
@@ -133,7 +173,7 @@ def enhance_prompt_i2v(image_path: str, prompt: str, retry_times: int = 3):
         try:
             response = client.chat.completions.create(
                 messages=message,
-                model="gpt-4.1",
+                model=get_minimax_image_model(),
                 temperature=0.01,
                 top_p=0.7,
                 stream=False,
@@ -155,9 +195,7 @@ def enhance_prompt_t2v(prompt: str, retry_times: int = 3):
     """
     Enhance a prompt used for text-2-video
     """
-    client = OpenAI(
-        api_key=f"{APPKEY}",
-    )
+    client = get_minimax_client()
     text = prompt.strip()
     sys_prompt = LM_ZH_SYS_PROMPT if is_chinese_prompt(text) else LM_EN_SYS_PROMPT
     for i in range(retry_times):
@@ -170,7 +208,7 @@ def enhance_prompt_t2v(prompt: str, retry_times: int = 3):
                         "content": f'{text}"',
                     },
                 ],
-                model="gpt-4.1",
+                model=get_minimax_text_model(),
                 temperature=0.01,
                 top_p=0.7,
                 stream=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ ftfy==6.2.0
 psutil==6.0.0
 av==12.0.0
 opencv-python==4.9.0.80
+openai>=1.0.0
 flash-attn==2.7.4.post1
 streamlit==1.50.0
 pyarrow==20.0.0

--- a/tests/test_prompt_enhancer.py
+++ b/tests/test_prompt_enhancer.py
@@ -1,0 +1,84 @@
+import os
+import types
+import unittest
+from unittest import mock
+
+from longcat_video.utils import prompt_enhancer
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        message = types.SimpleNamespace(content="enhanced prompt")
+        choice = types.SimpleNamespace(message=message)
+        return types.SimpleNamespace(choices=[choice])
+
+
+class FakeClient:
+    def __init__(self):
+        self.completions = FakeCompletions()
+        self.chat = types.SimpleNamespace(completions=self.completions)
+
+
+class PromptEnhancerMiniMaxTest(unittest.TestCase):
+    def setUp(self):
+        self.original_region = prompt_enhancer.MINIMAX_REGION
+        self.original_text_model = prompt_enhancer.MINIMAX_TEXT_MODEL
+        self.original_image_model = prompt_enhancer.MINIMAX_IMAGE_MODEL
+
+    def tearDown(self):
+        prompt_enhancer.MINIMAX_REGION = self.original_region
+        prompt_enhancer.MINIMAX_TEXT_MODEL = self.original_text_model
+        prompt_enhancer.MINIMAX_IMAGE_MODEL = self.original_image_model
+
+    def test_global_and_cn_base_urls_are_configured(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            prompt_enhancer.MINIMAX_REGION = "global_en"
+            self.assertEqual(
+                prompt_enhancer.get_minimax_base_url(),
+                "https://api.minimax.io/v1",
+            )
+
+            prompt_enhancer.MINIMAX_REGION = "cn_zh"
+            self.assertEqual(
+                prompt_enhancer.get_minimax_base_url(),
+                "https://api.minimaxi.com/v1",
+            )
+
+    def test_base_url_override_takes_precedence(self):
+        with mock.patch.dict(os.environ, {"MINIMAX_BASE_URL": "https://example.test/v1"}):
+            prompt_enhancer.MINIMAX_REGION = "cn_zh"
+            self.assertEqual(prompt_enhancer.get_minimax_base_url(), "https://example.test/v1")
+
+    def test_text_prompt_supports_configured_models(self):
+        client = FakeClient()
+        prompt_enhancer.MINIMAX_TEXT_MODEL = "MiniMax-M2.7"
+
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(prompt_enhancer, "get_minimax_client", return_value=client):
+            result = prompt_enhancer.enhance_prompt_t2v("make a short video")
+
+        self.assertEqual(result, "enhanced prompt")
+        self.assertEqual(client.completions.calls[0]["model"], "MiniMax-M2.7")
+
+    def test_image_prompt_uses_image_capable_model(self):
+        client = FakeClient()
+
+        compressed_image = types.SimpleNamespace(read=lambda: b"abc")
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(prompt_enhancer, "get_minimax_client", return_value=client), \
+                mock.patch.object(prompt_enhancer, "compress_image", return_value=compressed_image), \
+                mock.patch.object(prompt_enhancer, "encode_image", return_value="encoded"):
+            result = prompt_enhancer.enhance_prompt_i2v("image.png", "make a short video")
+
+        self.assertEqual(result, "enhanced prompt")
+        call = client.completions.calls[0]
+        self.assertEqual(call["model"], "MiniMax-M3")
+        self.assertEqual(call["messages"][1]["content"][1]["type"], "image_url")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Add MiniMax prompt-enhancement support with configurable global and CN endpoints.

Summary:
- configure the prompt enhancer with MiniMax API key, region, base URL override, and supported text/image model settings
- route text prompt enhancement through MiniMax-M3 by default while allowing MiniMax-M2.7
- route image prompt enhancement through MiniMax-M3
- add focused unit coverage for endpoint selection and prompt request model routing

Checks:
- `python3 -m unittest tests.test_prompt_enhancer`
- `python3 -m py_compile longcat_video/utils/prompt_enhancer.py tests/test_prompt_enhancer.py`
- `git diff --check`
- Required secret scan
